### PR TITLE
Fix build.sh to download the proper antkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/libs/
+/Cryptomator.AppDir/
+/squashfs-root/
+/antbuild/
+
+antkit.zip
+build.xml
+appimagetool.AppImage
+cryptomator-*

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-BUILD_VERSION=$1
+BUILD_VERSION=${1:-continuous}
+echo "Building Cryptomator ${BUILD_VERSION}"
+
+# download ant-kit
+curl -o antkit.zip -L https://github.com/cryptomator/cryptomator/releases/download/${BUILD_VERSION}/antkit.zip
+unzip antkit.zip
 
 # build application directory
 ant \


### PR DESCRIPTION
This is a small fix to actually download the antkit on linux. 
Also added a new .gitignore so that the files from the build process are not included in the repository.