### PR TITLE
StartupWMClass

### DIFF
--- a/resources/appimage/cryptomator.desktop
+++ b/resources/appimage/cryptomator.desktop
@@ -6,3 +6,4 @@ Icon=cryptomator
 Terminal=false
 Type=Application
 Categories=Utility;Security;FileTools;
+StartupWMClass=org.cryptomator.launcher.MainApplication


### PR DESCRIPTION
This prevents an additional icon to be opened in your Linux taskbar. Please note that this change should also be applied to the Ubuntu PPA and other Linux packages you maintain.

## Before
![before](https://user-images.githubusercontent.com/19509074/48970532-299f9280-efdb-11e8-9b6a-b2cfaaf0dc49.png)

## After

![after](https://user-images.githubusercontent.com/19509074/48970538-2c9a8300-efdb-11e8-8ff7-e47f52738c0b.png)

Notice how in 'After' there is only one icon rather than two.