### PR TITLE
Render appdata.xml dynamically and add <releases/> section

### DIFF
--- a/appimage-build.sh
+++ b/appimage-build.sh
@@ -5,6 +5,9 @@ BUILD_VERSION=${1:-SNAPSHOT}
 if [ ! -d ./Cryptomator ]; then echo "./Cryptomator does not exist."; exit 1; fi
 if [ ! -x $(readlink -e ./tools/appimagekit/squashfs-root/AppRun) ]; then echo "./tools/appimagekit/squashfs-root/AppRun not executable."; exit 1; fi
 
+# render appdata.xml
+./render-appdata-template.sh resources/appdata.template.xml $BUILD_VERSION > resources/appimage/org.cryptomator.Cryptomator.appdata.xml
+
 # prepare AppDir
 mv Cryptomator Cryptomator.AppDir
 mkdir -p Cryptomator.AppDir/usr/share/icons/hicolor/512x512/apps/

--- a/render-appdata-template.sh
+++ b/render-appdata-template.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+template_file=$1
+release_version=$2
+
+if [[ $# -ne 2 ]] ; then
+  echo """
+Usage:
+    ./render-appdata-template.sh TEMPLATE_FILE RELEASE_VERSION
+Example:
+    ./render-appdata-template.sh resources/appdata.template.xml 1.0.0
+    ./render-appdata-template.sh resources/appdata.template.xml SNAPSHOT
+    """
+  exit
+fi
+
+if [[ "$release_version" != "SNAPSHOT" ]] ; then
+  # non-SNAPSHOT release: render <releases/> section
+  version_suffix=`echo $release_version | sed -nr "s/[0-9]+\.[0-9]+\.[0-9]+(-.*)/\1/p"`
+  [ -z "$version_suffix" ] && release_type="stable" || release_type="development"
+  release_date=`date --iso-8601`
+
+  cat "$template_file" |
+    sed -e ':a' -e 'N' -e '$!ba' -e 's/{{{releases\(.*\)}}}/\1/g' \
+        -e "s/{{release_version}}/$release_version/g" \
+        -e "s/{{release_date}}/$release_date/g" \
+        -e "s/{{release_type}}/$release_type/g"
+else
+  # SNAPSHOT release: omit <releases/> section
+  cat "$template_file" |
+    sed -e':a' -e 'N' -e '$!ba' -e 's/{{{releases\(.*\)}}}//g'
+fi
+
+
+
+
+

--- a/resources/appdata.template.xml
+++ b/resources/appdata.template.xml
@@ -70,4 +70,19 @@
     <binary>cryptomator</binary>
   </provides>
   <launchable type="desktop-id">org.cryptomator.Cryptomator.desktop</launchable>
+  {{{releases
+  <releases>
+    <release version="{{release_version}}" date="{{release_date}}" type="{{release_type}}">
+      <url>https://github.com/cryptomator/cryptomator/releases/tag/{{release_version}}</url>
+      <artifacts>
+        <artifact type="binary">
+          <location>https://github.com/cryptomator/cryptomator/releases/download/{{release_version}}/cryptomator-{{release_version}}-x86_64.AppImage</location>
+        </artifact>
+        <artifact type="source">
+          <location>https://github.com/cryptomator/cryptomator/archive/{{release_version}}.tar.gz</location>
+        </artifact>
+      </artifacts>
+    </release>
+  </releases>
+  }}}
 </component>


### PR DESCRIPTION
The change modifies the build script so that the appdata.xml is rendered dynamically instead of being hard-coded.
The build script now calls the `render-appdata-template.sh` script which takes a template file and replaces all placeholders, e.g. `{{release_version}}`, with actual values. 
This makes it possible to include a [\<releases/>](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-releases) tag into the appdata.xml.
The script distinguishes between three types of builds:
* stable releases, e.g. `1.4.15`:
  * \<releases/> tag is included
  * release type is set to `stable`
  * release contains links to the source and binary downloads
* development releases e.g.  `1.5.0-alpha2`
  * \<releases/> tag is included
  * release type is set to `development`
  * release contains links to the source and binary download
* snapshot releases, i.e. `SNAPSHOT`
  * \<releases/> tag is omitted

## Examples
### Stable
```
./render-appdata-template.sh resources/appdata.template.xml 1.0.0
```
Output
```
...
  <releases>
    <release version="1.0.0" date="2019-10-20" type="stable">
      <url>https://github.com/cryptomator/cryptomator/releases/tag/1.0.0</url>
      <artifacts>
        <artifact type="binary">
          <location>https://github.com/cryptomator/cryptomator/releases/download/1.0.0/cryptomator-1.0.0-x86_64.AppImage</location>
        </artifact>
        <artifact type="source">
          <location>https://github.com/cryptomator/cryptomator/archive/1.0.0.tar.gz</location>
        </artifact>
      </artifacts>
    </release>
  </releases>
...
```
---
### Development
```
./render-appdata-template.sh resources/appdata.template.xml 1.5.0-alpha2
```
Output
```
...
  <releases>
    <release version="1.5.0-alpha2" date="2019-10-20" type="development">
      <url>https://github.com/cryptomator/cryptomator/releases/tag/1.5.0-alpha2</url>
      <artifacts>
        <artifact type="binary">
          <location>https://github.com/cryptomator/cryptomator/releases/download/1.5.0-alpha2/cryptomator-1.5.0-alpha2-x86_64.AppImage</location>
        </artifact>
        <artifact type="source">
          <location>https://github.com/cryptomator/cryptomator/archive/1.5.0-alpha2.tar.gz</location>
        </artifact>
      </artifacts>
    </release>
  </releases>
...
```
---
### Snapshot
```
./render-appdata-template.sh resources/appdata.template.xml SNAPSHOT
```
*releases tag is not rendered*
