### PR TITLE
Fixed wrong StartupWMClass

### DIFF
--- a/resources/appimage/AppDir/usr/share/applications/org.cryptomator.Cryptomator.desktop
+++ b/resources/appimage/AppDir/usr/share/applications/org.cryptomator.Cryptomator.desktop
@@ -6,4 +6,4 @@ Icon=org.cryptomator.Cryptomator
 Terminal=false
 Type=Application
 Categories=Utility;Security;FileTools;
-StartupWMClass=org.cryptomator.launcher.MainApplication
+StartupWMClass=org.cryptomator.launcher.Cryptomator$MainApp


### PR DESCRIPTION
This prevents an additional icon being opened in the GNOME dock when the application is pinned and it's opened, just as https://github.com/cryptomator/cryptomator-linux/pull/10 did. It also fixes https://github.com/cryptomator/cryptomator/issues/956.