### PR TITLE
Feature/migrate from bintray

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -13,7 +13,7 @@ jobs:
           java-version: 15
       - name: Download Buildkit (tagged) -- TODO remove hardcoded version
         if: startsWith(github.ref, 'refs/tags/')
-        run: curl -L https://github.com/cryptomator/cryptomator/releases/download/1.5.12/buildkit-linux.zip -o buildkit.zip
+        run: curl -L https://github.com/cryptomator/cryptomator/releases/download/1.5.11/buildkit-linux.zip -o buildkit.zip
       - name: Download Buildkit (latest)
         if: startsWith(github.ref, 'refs/heads/')
         run: curl -L https://github.com/cryptomator/cryptomator/releases/latest/download/buildkit-linux.zip -o buildkit.zip

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -178,8 +178,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: cryptomator-${APPIMG_VERSION}-x86_64.AppImage
-          asset_name: cryptomator-${APPIMG_VERSION}-x86_64.AppImage
+          asset_path: cryptomator-${{ env.APPIMG_VERSION }}-x86_64.AppImage
+          asset_name: cryptomator-${{ env.APPIMG_VERSION }}-x86_64.AppImage
           asset_content_type: application/vnd.appimage
       - name: Upload zsync file to GitHub releases
         uses: actions/upload-release-asset@v1.0.2
@@ -187,6 +187,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: cryptomator-${APPIMG_VERSION}-x86_64.AppImage.zsync
-          asset_name: cryptomator-${APPIMG_VERSION}-x86_64.AppImage.zsync
+          asset_path: cryptomator-${{ env.APPIMG_VERSION }}-x86_64.AppImage.zsync
+          asset_name: cryptomator-${{ env.APPIMG_VERSION }}-x86_64.AppImage.zsync
           asset_content_type: application/x-zsync

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -164,7 +164,7 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CRYPTOBOT_RELEASE_TOKEN }} # release as "cryptobot"
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -140,3 +140,53 @@ jobs:
           -H "X-Bintray-Override:1"
           -H "X-Bintray-Publish:1"
           https://api.bintray.com/content/cryptomator/cryptomator/${GITHUB_REF##*/}/cryptomator-${APPIMG_VERSION}-x86_64.AppImage.zsync
+
+  publish-github:
+    name: Publish on Github 
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') # only when tagged
+    needs: build-appimage
+    steps:
+      - name: Get version
+        id: getversion
+        run: echo "APPIMG_VERSION=${{ needs.build-appimage.outputs.appimage-version }}" >> $GITHUB_ENV
+      - name: Download AppImage
+        uses: actions/download-artifact@v1
+        with:
+          name: cryptomator-${{ env.APPIMG_VERSION }}-x86_64.AppImage
+          path: .
+      - name: Download AppImage.zsync
+        uses: actions/download-artifact@v1
+        with:
+          name: cryptomator-${{ env.APPIMG_VERSION }}-x86_64.AppImage.zsync
+          path: .
+      - name: Create release on Github
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: |
+            :construction: Work in Progress
+          draft: true
+          prerelease: false
+      - name: Upload appimage to GitHub releases
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: cryptomator-${APPIMG_VERSION}-x86_64.AppImage
+          asset_name: cryptomator-${APPIMG_VERSION}-x86_64.AppImage
+          asset_content_type: application/vnd.appimage
+      - name: Upload zsync file to GitHub releases
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: cryptomator-${APPIMG_VERSION}-x86_64.AppImage.zsync
+          asset_name: cryptomator-${APPIMG_VERSION}-x86_64.AppImage.zsync
+          asset_content_type: application/x-zsync

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -85,9 +85,9 @@ jobs:
           curl -L https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage -o ./tools/appimagekit/appimagetool.AppImage
           chmod +x ./tools/appimagekit/appimagetool.AppImage
           (cd ./tools/appimagekit && ./appimagetool.AppImage --appimage-extract)
-      - name: Build AppImage
+      - name: Build AppImage with update info
         run: >
-          ./tools/appimagekit/squashfs-root/AppRun Cryptomator.AppDir cryptomator-${BUILD_VERSION}-x86_64.AppImage -u 'bintray-zsync|cryptomator|cryptomator|cryptomator-linux|cryptomator-_latestVersion-x86_64.AppImage.zsync'
+          ./tools/appimagekit/squashfs-root/AppRun Cryptomator.AppDir cryptomator-${BUILD_VERSION}-x86_64.AppImage -u 'gh-releases-zsync|cryptomator|cryptomator-linux|latest|cryptomator-*-x86_64.AppImage.zsync'
       - name: Upload AppImage
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 15
-      - name: Download Buildkit (tagged)
+      - name: Download Buildkit (tagged) TODO: remove hardcoded version
         if: startsWith(github.ref, 'refs/tags/')
-        run: curl -L https://github.com/cryptomator/cryptomator/releases/download/${GITHUB_REF##*/}/buildkit-linux.zip -o buildkit.zip
+        run: curl -L https://github.com/cryptomator/cryptomator/releases/download/1.5.12/buildkit-linux.zip -o buildkit.zip
       - name: Download Buildkit (latest)
         if: startsWith(github.ref, 'refs/heads/')
         run: curl -L https://github.com/cryptomator/cryptomator/releases/latest/download/buildkit-linux.zip -o buildkit.zip
@@ -102,7 +102,7 @@ jobs:
   publish-bintray:
     name: Publish on Bintray
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') # only when tagged
+    if: ${{ false }} #startsWith(github.ref, 'refs/tags/') # only when tagged
     needs: build-appimage
     steps:
       - name: Get version

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -87,7 +87,7 @@ jobs:
           (cd ./tools/appimagekit && ./appimagetool.AppImage --appimage-extract)
       - name: Build AppImage with update info
         run: >
-          ./tools/appimagekit/squashfs-root/AppRun Cryptomator.AppDir cryptomator-${BUILD_VERSION}-x86_64.AppImage -u 'gh-releases-zsync|cryptomator|cryptomator-linux|latest|cryptomator-*-x86_64.AppImage.zsync'
+          ./tools/appimagekit/squashfs-root/AppRun Cryptomator.AppDir cryptomator-${BUILD_VERSION}-x86_64.AppImage -u 'gh-releases-zsync|cryptomator|cryptomator|latest|cryptomator-*-x86_64.AppImage.zsync'
       - name: Upload AppImage
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 15
-      - name: Download Buildkit (tagged) -- TODO remove hardcoded version
+      - name: Download Buildkit (tagged)
         if: startsWith(github.ref, 'refs/tags/')
-        run: curl -L https://github.com/cryptomator/cryptomator/releases/download/1.5.12/buildkit-linux.zip -o buildkit.zip
+        run: curl -L https://github.com/cryptomator/cryptomator/releases/download/${GITHUB_REF##*/}/buildkit-linux.zip -o buildkit.zip
       - name: Download Buildkit (latest)
         if: startsWith(github.ref, 'refs/heads/')
         run: curl -L https://github.com/cryptomator/cryptomator/releases/latest/download/buildkit-linux.zip -o buildkit.zip
@@ -102,7 +102,7 @@ jobs:
   publish-bintray:
     name: Publish on Bintray
     runs-on: ubuntu-latest
-    if: ${{ false }} #startsWith(github.ref, 'refs/tags/') # only when tagged
+    if: startsWith(github.ref, 'refs/tags/') # only when tagged
     needs: build-appimage
     steps:
       - name: Get version

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 15
-      - name: Download Buildkit (tagged) TODO: remove hardcoded version
+      - name: Download Buildkit (tagged) -- TODO remove hardcoded version
         if: startsWith(github.ref, 'refs/tags/')
         run: curl -L https://github.com/cryptomator/cryptomator/releases/download/1.5.12/buildkit-linux.zip -o buildkit.zip
       - name: Download Buildkit (latest)

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -13,7 +13,7 @@ jobs:
           java-version: 15
       - name: Download Buildkit (tagged) -- TODO remove hardcoded version
         if: startsWith(github.ref, 'refs/tags/')
-        run: curl -L https://github.com/cryptomator/cryptomator/releases/download/1.5.11/buildkit-linux.zip -o buildkit.zip
+        run: curl -L https://github.com/cryptomator/cryptomator/releases/download/1.5.12/buildkit-linux.zip -o buildkit.zip
       - name: Download Buildkit (latest)
         if: startsWith(github.ref, 'refs/heads/')
         run: curl -L https://github.com/cryptomator/cryptomator/releases/latest/download/buildkit-linux.zip -o buildkit.zip


### PR DESCRIPTION
This PR is one step for #31.

It adds Github Releases as a second deploy target  and changes the AppImage update info.